### PR TITLE
Replace â€” with semicolon

### DIFF
--- a/src/views/docs/advanced/third-party.html
+++ b/src/views/docs/advanced/third-party.html
@@ -135,7 +135,7 @@ var myLibrary = require('myLibrary/dist/library');
 ## Handling modules that do not use CommonJS
 
 Many Bower modules are just plain JavaScript files that don't use the CommonJS
-module syntax â€” an example might be a jQuery plugin.
+module syntax; an example might be a jQuery plugin.
 
 Fabricator includes both the [Imports Loader](https://github.com/webpack/imports-loader)
 and the [Script Loader](https://github.com/webpack/script-loader) to handle these cases.


### PR DESCRIPTION
I know that is typically a right quote, but it seems a semi colon (which is right next to the right quote) might have been the intended stroke.
